### PR TITLE
Upgrade of socket.io-client to 1.3.4

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -22,11 +22,9 @@
         if (!destination.port) {
             destination.port = destination.protocol === 'https:' ? 443 : 80;
         }
-        console.log(destination);
 
         if (!initialized) exports.init();
 
-        console.log(options);
         if (typeof tunnelServer === 'undefined') return io(destinationUrl, options);   // Direct connection
 
         options = options || {};

--- a/lib/main.js
+++ b/lib/main.js
@@ -22,15 +22,17 @@
         if (!destination.port) {
             destination.port = destination.protocol === 'https:' ? 443 : 80;
         }
+        console.log(destination);
 
         if (!initialized) exports.init();
 
-        if (typeof tunnelServer === 'undefined') return io.connect(destinationUrl, options);   // Direct connection
+        console.log(options);
+        if (typeof tunnelServer === 'undefined') return io(destinationUrl, options);   // Direct connection
 
         options = options || {};
         options['force new connection'] = true;   // Allows one tunnel server to handle multiple destinations
 
-        return io.connect('http://localhost:' + tunnelPort + '/' +
+        return io('http://localhost:' + tunnelPort + '/' +
             '?protocol=' + destination.protocol.replace(':', '')  +
             '&hostname=' + destination.hostname +
             '&port=' + destination.port, options);

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "mocha test/*.js"
   },
   "dependencies": {
-    "socket.io-client": "0.9.16"
+    "socket.io-client": "^1.3.4"
   },
   "devDependencies": {
     "mocha": "",


### PR DESCRIPTION
Some dependency seemed to not work out-of-the-box for socket.io-proxy. Upgrading socket.io-client seems to have done the trick.