### PR TITLE
Updated socket.io-client@1.3.5, randomised tunnelPort to avoid collisions, Namespaced Socket connections now work

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -13,9 +13,19 @@
     var url = require('url');
     var io = require('socket.io-client');
 
-    var tunnelPort = 61423;
+    // port range, chosen from http://stackoverflow.com/a/28369841
+    var tunnelPort = getRandomInt(43124, 44320);
     var tunnelServer;
     var initialized = false;
+
+    /**
+     * Returns a random integer between min (inclusive) and max (inclusive)
+     * Using Math.round() will give you a non-uniform distribution!
+     * ( From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random )
+     */
+    function getRandomInt(min, max) {
+        return Math.floor(Math.random() * (max - min + 1)) + min;
+    }
 
     exports.connect = function(destinationUrl, options) {
         var destination = url.parse(destinationUrl);

--- a/lib/main.js
+++ b/lib/main.js
@@ -59,11 +59,20 @@
             var requestUrl = url.parse(request.url, true);
             var hostname = requestUrl.query.hostname;
             var port = requestUrl.query.port;
+            var qs = [];
+            
+            for (var i in requestUrl.query){
+                if (['protocol','hostname','port'].indexOf(i) == -1){
+                    qs.push( i + '=' + requestUrl.query[i] );
+                }
+            }
+
+            qs = '?'+qs.join('&');
 
             var options = {
                 hostname: typeof proxy !== 'undefined' ? proxy.hostname : hostname,
                 port: typeof proxy !== 'undefined' ? proxy.port : port,
-                path: requestUrl.pathname + '?t=' + requestUrl.query.t,
+                path: requestUrl.pathname + qs,
                 method: request.method,
                 headers: request.headers
             };

--- a/lib/main.js
+++ b/lib/main.js
@@ -33,6 +33,8 @@
             destination.port = destination.protocol === 'https:' ? 443 : 80;
         }
 
+        var pathname = destination.pathname || '/';
+
         if (!initialized) exports.init();
 
         if (typeof tunnelServer === 'undefined') return io.connect(destinationUrl, options);   // Direct connection
@@ -40,7 +42,7 @@
         options = options || {};
         options['force new connection'] = true;   // Allows one tunnel server to handle multiple destinations
 
-        return io.connect('http://localhost:' + tunnelPort + '/' +
+        return io.connect('http://localhost:' + tunnelPort + pathname +
             '?protocol=' + destination.protocol.replace(':', '')  +
             '&hostname=' + destination.hostname +
             '&port=' + destination.port, options);

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "mocha test/*.js"
   },
   "dependencies": {
-    "socket.io-client": "0.9.16"
+    "socket.io-client": ">=0.9.16"
   },
   "devDependencies": {
     "mocha": "",


### PR DESCRIPTION
Had to change the way the path was formed as it was missing required
new query string parameters that were introduced in socket.io 1.0.